### PR TITLE
Adding bulk delete accounts

### DIFF
--- a/lib/rsalesloft.rb
+++ b/lib/rsalesloft.rb
@@ -8,4 +8,8 @@ module RSalesloft
   def self.configure(config = {})
     RSalesloft::Config.configure(config)
   end
+
+  def self.remaining_credits
+    RSalesloft::Connection.remaining_credits
+  end
 end

--- a/lib/rsalesloft.rb
+++ b/lib/rsalesloft.rb
@@ -3,8 +3,6 @@ require "rsalesloft/connection"
 require "rsalesloft/resources"
 
 module RSalesloft
-  VERSION = '0.2'
-
   def self.configure(config = {})
     RSalesloft::Config.configure(config)
   end

--- a/lib/rsalesloft/config.rb
+++ b/lib/rsalesloft/config.rb
@@ -2,10 +2,14 @@ module RSalesloft
   class Config
     class << self
       attr_accessor :api_key
+      attr_reader :redis_pool, :redis_key_for_max_credits, :redis_key_prefix_for_remaining_credits
 
       def configure(config)
         @api_key = config[:api_key]
 
+        @redis_pool = config[:redis_pool]
+        @redis_key_for_max_credits = config[:redis_key_for_max_credits] || "salesloft-api-ratelimit-max"
+        @redis_key_prefix_for_remaining_credits = config[:redis_key_prefix_for_remaining_credits] || "salesloft-api-ratelimit-remaining-"
         self
       end
 

--- a/lib/rsalesloft/config.rb
+++ b/lib/rsalesloft/config.rb
@@ -2,10 +2,12 @@ module RSalesloft
   class Config
     class << self
       attr_accessor :api_key
-      attr_reader :redis_pool, :redis_key_for_max_credits, :redis_key_prefix_for_remaining_credits
+      attr_reader :redis_pool, :redis_key_for_max_credits, :redis_key_prefix_for_remaining_credits, :max_credits_per_minute
 
       def configure(config)
         @api_key = config[:api_key]
+
+        @max_credits_per_minute = config[:max_credits_per_minute] || 600
 
         @redis_pool = config[:redis_pool]
         @redis_key_for_max_credits = config[:redis_key_for_max_credits] || "salesloft-api-ratelimit-max"

--- a/lib/rsalesloft/connection.rb
+++ b/lib/rsalesloft/connection.rb
@@ -6,24 +6,39 @@ module RSalesloft
   class Connection 
     class << self
       def get(path, options = {})
-        connection.get(
-          path, options
-        ).body
+        res = connection.get(path, options)
+        {
+          body: res.body,
+          headers: res.headers
+        }
       end
     
       def post(path, req_body)
-        connection.post do |req|
+        res = connection.post do |req|
           req.url(path)
           req.body = req_body
-        end.body
+        end
+
+        {
+          body: res.body,
+          headers: res.headers
+        }
       end
     
       def put(path, options = {})
-        connection.put(path, options).body
+        res = connection.put(path, options)
+        {
+          body: res.body,
+          headers: res.headers
+        }
       end
     
       def delete(path, options = {})
-        connection.delete(options).body
+        res = connection.delete(path, options)
+        {
+          body: res.body,
+          headers: res.headers
+        }
       end
 
       private

--- a/lib/rsalesloft/connection.rb
+++ b/lib/rsalesloft/connection.rb
@@ -7,10 +7,9 @@ module RSalesloft
     class << self
       def get(path, options = {})
         res = connection.get(path, options)
-        {
-          body: res.body,
-          headers: res.headers
-        }
+
+        update_remaining_credits(res.headers)
+        res.body
       end
     
       def post(path, req_body)
@@ -19,29 +18,53 @@ module RSalesloft
           req.body = req_body
         end
 
-        {
-          body: res.body,
-          headers: res.headers
-        }
+        update_remaining_credits(res.headers)
+        res.body
       end
     
       def put(path, options = {})
         res = connection.put(path, options)
-        {
-          body: res.body,
-          headers: res.headers
-        }
+        update_remaining_credits(res.headers)
+        res.body
       end
     
       def delete(path, options = {})
         res = connection.delete(path, options)
-        {
-          body: res.body,
-          headers: res.headers
-        }
+        update_remaining_credits(res.headers)
+        res.body
+      end
+
+      def remaining_credits
+        redis_pool.with { |conn| (conn.get(redis_key_for_remaining_credits) || max_credits).to_i }
       end
 
       private
+
+      def update_remaining_credits(headers)
+        redis_pool.with do |conn|
+          # Since there is a new key every minute, expiring a little later is okay since we won't hit this
+          # key once the minute changes.
+          conn.set(redis_key_for_remaining_credits, headers["x-ratelimit-remaining-minute"], ex: 65)
+  
+          # The max credits are more stable, only refresh once every day
+          conn.set(RSalesloft::Config.redis_key_for_max_credits, headers["x-ratelimit-limit-minute"] || 600, ex: 1.day.to_i)
+        end
+      end
+
+      def max_credits
+        redis_pool.with { |conn| (conn.get(RSalesloft::Config.redis_key_for_max_credits) || 600).to_i }
+      end
+
+      def redis_pool
+        RSalesloft::Config.redis_pool
+      end
+
+      def redis_key_for_remaining_credits
+        # Salesloft ratelimits based on the current minute (X requests from 11:00:00.000 to 11:00:00.999) and
+        # the limit is refreshed when the minute changes. This key returns the current minute.
+        # 11th Nov 11:29 PM -> 2329
+        "#{RSalesloft::Config.redis_key_prefix_for_remaining_credits}#{Time.current.strftime("%H%M")}"
+      end
 
       def connection
         Faraday.new(url: "https://api.salesloft.com/v2", headers: {

--- a/lib/rsalesloft/resources/accounts.rb
+++ b/lib/rsalesloft/resources/accounts.rb
@@ -21,6 +21,10 @@ module RSalesloft::Resources
         RSalesloft::Connection.put(accounts_path(id), options)
       end
 
+      def bulk_delete(ids)
+        RSalesloft::Connection.post("bulk_delete_accounts", {ids: ids}) # undocumented but used by their frontend
+      end
+
       private 
 
       def accounts_path(id = nil)

--- a/lib/rsalesloft/version.rb
+++ b/lib/rsalesloft/version.rb
@@ -1,0 +1,3 @@
+module RSalesloft
+  VERSION = '0.2'
+end

--- a/rsalesloft.gemspec
+++ b/rsalesloft.gemspec
@@ -1,6 +1,8 @@
 # encoding: utf-8
-$:.push File.expand_path('../lib', __FILE__)
-require 'rsalesloft'
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'rsalesloft/version'
 
 Gem::Specification.new do |s|
   s.name = "atob-rsalesloft"

--- a/rsalesloft.gemspec
+++ b/rsalesloft.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 require 'rsalesloft'
 
 Gem::Specification.new do |s|
-  s.name = "rsalesloft"
+  s.name = "atob-rsalesloft"
   s.version = RSalesloft::VERSION
   s.authors = ["Auree Aubert"]
   s.email = "contact@auree.me"


### PR DESCRIPTION
When data was imported from Saleforce into Salesloft, both `Opportunities` and `Accounts` were copied.

`Opportunities` mapped 1 to 1 to `CustomerApplication` and in the Salesloft world they are `Persons`
`Accounts` don't map to anything.

The problem is that in Salesloft `Accounts` have owners (reps) and that conflicts with the ownership of `Persons` and that both confuses the reps and don't bring any value.

Craig, Darren and I asked Salesloft to bulk delete but they won't, so we need to do it.
They suggested selecting 100 records at a time in the UI and clicking a button to delete, but we have over 900k records.
Thus I looked how their UI was handling it and discovered this undocumented API, that we're going to use.